### PR TITLE
Prevent migration errors by checking table existence before execution

### DIFF
--- a/src/FilamentDatabaseScheduleServiceProvider.php
+++ b/src/FilamentDatabaseScheduleServiceProvider.php
@@ -41,9 +41,6 @@ class FilamentDatabaseScheduleServiceProvider extends PluginServiceProvider
     //     'plugin-filament-database-schedule' => __DIR__ . '/../resources/dist/filament-database-schedule.js',
     // ];
 
-
-
-
     public function register()
     {
         $this->callAfterResolving(Factory::class, function (Factory $factory) {
@@ -55,17 +52,14 @@ class FilamentDatabaseScheduleServiceProvider extends PluginServiceProvider
         parent::register();
     }
 
-
-
     public function boot()
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../resources/svg' => public_path('vendor/' . static::$name),
             ], static::$name);
-        }
+        }        
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
-
         $this->publishes([
             __DIR__ . '/../database/migrations/' => database_path('migrations'),
         ], 'filament-database-schedule-migrations');
@@ -74,18 +68,21 @@ class FilamentDatabaseScheduleServiceProvider extends PluginServiceProvider
         $model = $config->get('filament-database-schedule.model');
         $model::observe(ScheduleObserver::class);
 
-        $this->app->resolving(BaseSchedule::class, function ($schedule) {
-            $schedule = app(Schedule::class, ['schedule' => $schedule]);
-            return $schedule->execute();
-        });
+        if (Schema::hasTable($config->get('filament-database-schedule.table.schedules', 'schedules'))) {
+            $this->app->resolving(BaseSchedule::class, function ($schedule) {
+                $schedule = app(Schedule::class, ['schedule' => $schedule]);
+                return $schedule->execute();
+            });
+        }
 
         $this->commands([
             TestJobCommand::class,
             PhpUnitTestJobCommand::class,
             ScheduleClearCacheCommand::class,
-        ]);
+        ]);        
         parent::boot();
     }
+    
     public function configurePackage(Package $package): void
     {
         $package


### PR DESCRIPTION
This change helps to prevent errors when executing migrations, as the presence of a particular database table can cause bugs in the application. By checking if the table exists before performing any actions related to migrations, the code aims to avoid potential issues that could arise from attempting to interact with a non-existent table. This verification ensures a more stable execution of the migration process and helps to maintain the integrity of the application's data and schema.