### PR TITLE
Switch Status from Boolean to Enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "awcodes/filament-table-repeater": "^2.0.4",
         "filament/filament": "^3.0.47",
         "spatie/laravel-package-tools": "^1.13.5",

--- a/database/migrations/2023_12_20_173900_change_status_type_in_schedule_table.php
+++ b/database/migrations/2023_12_20_173900_change_status_type_in_schedule_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeStatusTypeInScheduleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(Config::get('filament-database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->enum('new_status', ['active', 'inactive', 'trashed'])->default('active')->after('status');
+        });
+
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 0)->update(['new_status' => 'inactive']);
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 1)->update(['new_status' => 'active']);
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 3)->update(['new_status' => 'trashed']);
+
+        Schema::table(Config::get('filament-database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->renameColumn('new_status', 'status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(Config::get('filament-database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->boolean('old_status')->default(true)->after('status');
+        });
+
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 'inactive')->update(['old_status' => 0]);
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 'active')->update(['old_status' => 1]);
+        DB::table(Config::get('filament-database-schedule.table.schedules', 'schedules'))->where('status', 'trashed')->update(['old_status' => 3]);
+
+        Schema::table(Config::get('filament-database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->renameColumn('old_status', 'status');
+        });
+    }
+}

--- a/src/Enums/Status.php
+++ b/src/Enums/Status.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace HusamTariq\FilamentDatabaseSchedule\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum Status: string implements HasIcon, HasColor, HasLabel {
+
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Trashed = 'trashed';
+
+    public function getColor(): string | array | null
+    {
+        return match ($this) {
+            self::Active => 'success',
+            self::Inactive => 'warning',
+            self::Trashed => 'danger',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return match ($this) {
+            self::Active => 'heroicon-o-check-circle',
+            self::Inactive => 'heroicon-o-document',
+            self::Trashed => 'heroicon-o-x-circle',
+        };
+    }
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::Active => __('filament-database-schedule::schedule.status.active'),
+            self::Inactive => __('filament-database-schedule::schedule.status.inactive'),
+            self::Trashed => __('filament-database-schedule::schedule.status.trashed'),
+        };
+    }
+}

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -2,6 +2,7 @@
 
 namespace HusamTariq\FilamentDatabaseSchedule\Models;
 
+use HusamTariq\FilamentDatabaseSchedule\Enums\Status;
 use Illuminate\Console\Scheduling\ManagesFrequencies;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -11,10 +12,6 @@ class Schedule extends Model
 {
     use ManagesFrequencies;
     use SoftDeletes;
-
-    public const STATUS_INACTIVE = 0;
-    public const STATUS_ACTIVE = 1;
-    public const STATUS_TRASHED = 2;
 
     /**
      * The database table used by the model.
@@ -58,6 +55,7 @@ class Schedule extends Model
         'options' => 'array',
         'options_with_value' => 'array',
         'environments' => 'array',
+        'status' => Status::class,
     ];
 
     /**
@@ -80,12 +78,12 @@ class Schedule extends Model
 
     public function scopeInactive($query)
     {
-        return $query->where('status', false);
+        return $query->where('status', Status::Inactive);
     }
 
     public function scopeActive($query)
     {
-        return $query->where('status', true);
+        return $query->where('status', Status::Active);
     }
 
     public function getArguments(): array

--- a/src/Observer/ScheduleObserver.php
+++ b/src/Observer/ScheduleObserver.php
@@ -2,6 +2,7 @@
 
 namespace HusamTariq\FilamentDatabaseSchedule\Observer;
 
+use HusamTariq\FilamentDatabaseSchedule\Enums\Status;
 use HusamTariq\FilamentDatabaseSchedule\Http\Services\ScheduleService;
 use HusamTariq\FilamentDatabaseSchedule\Models\Schedule;
 
@@ -20,14 +21,14 @@ class ScheduleObserver
     public function deleted(Schedule $schedule)
     {
 
-        $schedule->status = Schedule::STATUS_TRASHED;
+        $schedule->status = Status::Trashed;
         $schedule->saveQuietly();
         $this->clearCache();
     }
 
     public function restored(Schedule $schedule)
     {
-        $schedule->status = Schedule::STATUS_INACTIVE;
+        $schedule->status = Status::Inactive;
         $schedule->saveQuietly();
     }
 


### PR DESCRIPTION

Boolean can only be true or false. For example, when using an MSSQL database, the boolean column is converted to a bit() type, which can only be 0, 1, or NULL. If 3 is entered, it is stored as 1 in the database. When reading the bit() from the database without casting in the model, the data type assumed is string, which is then "0" or "1". The constants in the model are of type integer, which is why, when using MSSQL, the Filamentmethods icons() and colors() do not return the desired result because type-safe comparison is performed here.

To solve this issue, I have created an Enum for the status and accordingly adjusted the database.