### PR TITLE
Bugfix view

### DIFF
--- a/resources/views/components/repeater-table.blade.php
+++ b/resources/views/components/repeater-table.blade.php
@@ -141,7 +141,7 @@
                                                         {{ __('forms::components.repeater.buttons.move_item.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-switch-vertical class="w-5 h-5 md:!w-4 md:!h-4"/>
+                                                    <x-heroicon-s-arrows-up-down class="w-5 h-5 md:!w-4 md:!h-4"/>
                                                 </button>
                                             @endunless
 
@@ -159,7 +159,7 @@
                                                         {{ __('forms::components.repeater.buttons.clone_item.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-duplicate class="w-5 h-5 md:!w-4 md:!h-4"/>
+                                                    <x-heroicon-s-square-2-stack class="w-5 h-5 md:!w-4 md:!h-4"/>
                                                 </button>
                                             @endunless
 

--- a/resources/views/components/repeater-table.blade.php
+++ b/resources/views/components/repeater-table.blade.php
@@ -204,13 +204,13 @@
 
         @if (! $isItemCreationDisabled)
             <div class="relative flex justify-center">
-                <x-forms::button
+                <x-filament::button
                     :wire:click="'dispatchFormEvent(\'repeater::createItem\', \'' . $getStatePath() . '\')'"
                     size="sm"
                     type="button"
                 >
                     {{ $getCreateItemButtonLabel() }}
-                </x-forms::button>
+                </x-filament::button>
             </div>
         @endif
     </div>


### PR DESCRIPTION
In order for the command "php artisan view:cache" to work properly, the icon names need to be adjusted to the new standard. Unfortunately, the button-component cannot be found and needs to be adjusted as well.