### PR TITLE
Switch Kernel Class

### DIFF
--- a/src/Http/Services/CommandService.php
+++ b/src/Http/Services/CommandService.php
@@ -2,7 +2,7 @@
 
 namespace HusamTariq\FilamentDatabaseSchedule\Http\Services;
 
-use App\Console\Kernel;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Collection;
 
 class CommandService


### PR DESCRIPTION
In Laravel version 11, the Kernel.php file has been removed from the directory structure. Therefore, it is no longer present in a fresh installation.
Fixing #37 