### PR TITLE
Update 2023_02_26_172600_create_schedule_table.php

### DIFF
--- a/database/migrations/2023_02_26_172600_create_schedule_table.php
+++ b/database/migrations/2023_02_26_172600_create_schedule_table.php
@@ -36,7 +36,7 @@ class CreateScheduleTable extends Migration
             $table->boolean('sendmail_error')->default(false);
             $table->boolean('log_success')->default(true);
             $table->boolean('log_error')->default(true);
-            $table->boolean('status')->default(true);
+            $table->tinyInteger('status')->default(1);
             $table->boolean('run_in_background')->default(false);
             $table->boolean('sendmail_success')->default(false);
 


### PR DESCRIPTION
I've installed your plugin on fresh Laravel 10 with latest filament. I'm using postgres 12 as a database, also tried on Postgres 15, same error: after runing php artisan migrate, i got an error, because of the wrong data type: 

` 
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type boolean: "3" (Connection: pgsql, SQL: update "schedules" set "new_status" = trashed where "status" = 3)
`

![image](https://github.com/husam-tariq/filament-database-schedule/assets/17369868/21d167fb-d740-470a-bb0f-dc92ddfb22ff)
