### PR TITLE
Package not compatible with filament-table-repeater version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "awcodes/filament-table-repeater": "^2.0.4|^3.1",
+        "awcodes/filament-table-repeater": "^2.0.4",
         "filament/filament": "^3.0.47",
         "spatie/laravel-package-tools": "^1.13.5",
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"


### PR DESCRIPTION
Since the namespace has changed in version 3, your package is not compatible with Version 3. I suggest to have a new Release for FIlament 4.0 with table-repeater 3 for older filament releases stick with table-repeater 2